### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/miichom/lodestone/security/code-scanning/1](https://github.com/miichom/lodestone/security/code-scanning/1)

Add an explicit `permissions` block for the `test` job in `.github/workflows/ci-verify.yml` so it does not inherit potentially broad defaults.  
Best minimal fix without changing functionality: set `contents: read` on `jobs.test`, since this job only needs to checkout and read repository code to run tests.

Edit location:
- File: `.github/workflows/ci-verify.yml`
- Region: under `jobs.test` (right after `runs-on` is a clear placement)

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
